### PR TITLE
Fix JSON formatting in sodium-options.json

### DIFF
--- a/versions/neoforge/1.21.1/config/sodium-options.json
+++ b/versions/neoforge/1.21.1/config/sodium-options.json
@@ -3,6 +3,6 @@
     "cpu_render_ahead_limit": 4
   },
   "performance": {
-    "use_entity_culling": false,
-  },
+    "use_entity_culling": false
+  }
 }

--- a/versions/neoforge/1.21.1/index.toml
+++ b/versions/neoforge/1.21.1/index.toml
@@ -30,7 +30,7 @@ hash = "01fccbbb144a4bd999c5127480e587e626cf6552ff390eeec85a7e68aaed1d9f"
 
 [[files]]
 file = "config/sodium-options.json"
-hash = "8d36f9cba8f5254dee76dcaa23a0eecf5ba68019f7ea85f4dae489b6659f5b1d"
+hash = "7024ae4da9a2af7955ff6e5b33c496e6aadcc5f7f3d0a9192294697ae9eaff68"
 
 [[files]]
 file = "config/threadtweak.json"

--- a/versions/neoforge/1.21.1/pack.toml
+++ b/versions/neoforge/1.21.1/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "5e2ddbe80971a5ee1767a72b059ad0d7ca3541fbcfcd742bd3810f3cf52f095a"
+hash = "c520a8ab290182247493e5e7255124ece2aeffe2716509e7759cb17775276977"
 
 [versions]
 minecraft = "1.21.1"


### PR DESCRIPTION
Extra commas caused Sodium to fail to read the config file. `packwiz refresh` was run, there should be no issue merging this.